### PR TITLE
Melhoria usabilidade link

### DIFF
--- a/docs/ambiente-react-native/android/emulador.md
+++ b/docs/ambiente-react-native/android/emulador.md
@@ -45,7 +45,7 @@ Clique no botão **Settings** e na aba **Account** faça login com sua conta cri
 
 Após realizado login, ainda no menu **Settings**, na aba **ADB** precisamos informar o caminho da nossa SDK do Android
 
-Selecione a opção **Use Custom Android SDK Tools** no Genymotion e utilize o caminho onde você extraiu os arquivos baixados do site do Android anteriormente (Ex.: `C:\Android\Sdk` ou `~/Android/Sdk`).
+Selecione a opção **Use Custom Android SDK Tools** no Genymotion e utilize o caminho onde você extraiu os arquivos baixados do site do Android [anteriormente](ambiente-react-native/android/linux#configurando-sdk-do-android-no-linux) (Ex.: `C:\Android\Sdk` ou `~/Android/Sdk`).
 
 Sua configuração deve ficar parecida com essa:
 


### PR DESCRIPTION
Adicionei um link para a instalação do Android para que o usuário possa clicar e ir direto ao tutorial de download do Android. As vezes o usuário pode fazer a instalação do Ubuntu e sair da página quando ver o titulo "Arch Linux"